### PR TITLE
Add support for devices with multiple connected nodes 

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,7 @@
 {
   "files.eol": "\n",
   "editor.codeActionsOnSave": {
-    "source.fixAll.eslint": true
+    "source.fixAll.eslint": "explicit"
   },
   "editor.rulers": [ 140 ],
   "eslint.enable": true

--- a/src/helki_client.ts
+++ b/src/helki_client.ts
@@ -34,7 +34,7 @@ interface Node {
   addr: string;
   installed?: boolean;
   lost?: boolean;
-  uid: string;
+  uid?: string;
 }
 
 interface GroupedDevices {

--- a/src/helki_client.ts
+++ b/src/helki_client.ts
@@ -34,6 +34,7 @@ interface Node {
   addr: string;
   installed?: boolean;
   lost?: boolean;
+  uid: string;
 }
 
 interface GroupedDevices {

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -76,8 +76,10 @@ export class Technotherm implements DynamicPlatformPlugin {
 
           // Devices can have multiple nodes, register an accessory for each
           for (const node of nodes) {
+            // Use Node attributes for the accessory display name and UUID gen
+            // but fallback to Device attributes in case they're undefined (i.e. Devices with a single node)
             const accessoryName = node.name || device.name;
-            const accessoryUUID = this.api.hap.uuid.generate(node.uid); // Use dev_id to generate a UUID
+            const accessoryUUID = this.api.hap.uuid.generate(node.uid || device.dev_id);
             const existingAccessory = this.accessories.find(accessory => accessory.UUID === accessoryUUID);
 
             if (existingAccessory) {

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -90,6 +90,13 @@ export class Technotherm implements DynamicPlatformPlugin {
                   this.log.warn(`existing accessory: ${error}`);
                 }
               } else {
+                // If the node has been renamed, update the corresponding accessory
+                if (existingAccessory.displayName !== accessoryName) {
+                  this.log.info(`Renaming accessory from ${existingAccessory.displayName} to ${accessoryName}`);
+                  existingAccessory.displayName = accessoryName;
+                  this.api.updatePlatformAccessories([existingAccessory]);
+                }
+
                 // Accessory exists, restore from cache
                 this.log.info('Restoring existing accessory from cache:', existingAccessory.displayName);
                 new Radiator(this, existingAccessory, helki);


### PR DESCRIPTION
## Context

The discovery code right now assumes that every device registered to a home/group maps to a single radiator unit. Whilst this might be true for homes with just one connected radiator or newer units that contain a built-in controller, it doesn't work for setups where radiators require an additional hub (Smartbox) to comm out to the API, as only the first node associated with a device is registered.

![Screenshot 2024-03-29 at 3 46 28 PM](https://github.com/duggan/homebridge-technotherm/assets/3799640/6eab4057-1569-4a2e-b03d-6b9a2b0ee872)

## Changes

This PR follows on the discussed in https://github.com/duggan/homebridge-technotherm/issues/28:

- Update the accessory discovery code to handle devices with multiple connected nodes
  - Accessory UUID generation is now seeded using the Node UID, previously was the Device UID. This will require that devices previously registered using the device ID to be manually removed from Homebridge cache, which is not high-impacting in this case, but please let me know if you disagree
- Check if nodes have been renamed against the accessories cache, and if so, update the renamed accessory within Homebridge

These changes should work for both your setup (@duggan) and mine. They are based on the following observations/assumptions:

- Devices represent the client that calls the Helki API
- A device can have multiple nodes associated with them
- A node represents a physical radiator/heater unit
- A node can only be connected to a single device at a time (at least for the units I have)

## Other

Changing the target temperature isn't working for me currently due to some API errors. I'm looking into this and raise a second PR to cover this separately.
