### PR TITLE
fix: Prevent socket disconnections due to invalid auth

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "displayName": "Technotherm",
   "name": "homebridge-technotherm",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Controls for Technotherm electric radiators.",
   "license": "Apache-2.0",
   "repository": {

--- a/src/helki_client.ts
+++ b/src/helki_client.ts
@@ -226,6 +226,37 @@ class HelkiClient {
 
       callback(data.body);
     });
+
+    socket.on('connect_timeout', () => {
+      this.log.warn('Socket connection timed out');
+    });
+
+    socket.on('reconnecting', async (attempt) => {
+      this.log.info('Reconnecting to socket. Attempt: ', attempt);
+
+      await this.checkRefresh();
+      socket.io.opts.query.token = this.accessToken;
+    });
+
+    socket.on('reconnect_error', (error) => {
+      this.log.error('Socket reconnection failed: ', error);
+    });
+
+    socket.on('connect_error', (error) => {
+      this.log.error('Socket connection failed: ', error);
+    });
+
+    socket.on('disconnect', async (data) => {
+      this.log.debug('Socket disconnected, attempting reconnect: ', data);
+
+      await this.checkRefresh();
+      socket.io.opts.query.token = this.accessToken;
+      socket.connect();
+    });
+
+    socket.on('connect', () => {
+      this.log.debug('Connected to socket');
+    });
   }
 
   private async auth(): Promise<void> {


### PR DESCRIPTION
Token is not refreshed before reconnecting the socket, causing the server to disconnect. This PR ensures the token is valid before reconnecting.